### PR TITLE
Ignore non existent values

### DIFF
--- a/JSONPatch.xcodeproj/project.pbxproj
+++ b/JSONPatch.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		4DDA51EB219AAD8D00BA7704 /* NSArray+DeepCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDA51EA219AAD8D00BA7704 /* NSArray+DeepCopy.swift */; };
 		4DDA51ED219AADE000BA7704 /* NSDictionary+DeepCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDA51EC219AADE000BA7704 /* NSDictionary+DeepCopy.swift */; };
 		4DF8B18621B1C5E700CAABEE /* JSONPatchGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF8B18521B1C5E700CAABEE /* JSONPatchGenerator.swift */; };
+		CC4BF61423DB0BD100485D08 /* JSONCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4BF61323DB0BD100485D08 /* JSONCodableTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		4DDA51EA219AAD8D00BA7704 /* NSArray+DeepCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSArray+DeepCopy.swift"; sourceTree = "<group>"; };
 		4DDA51EC219AADE000BA7704 /* NSDictionary+DeepCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDictionary+DeepCopy.swift"; sourceTree = "<group>"; };
 		4DF8B18521B1C5E700CAABEE /* JSONPatchGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONPatchGenerator.swift; sourceTree = "<group>"; };
+		CC4BF61323DB0BD100485D08 /* JSONCodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONCodableTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,10 +143,11 @@
 		4D22EB33219879EF00729769 /* JSONPatchTests */ = {
 			isa = PBXGroup;
 			children = (
+				4D5242CF21CD6F8100030720 /* ArrayTests.swift */,
 				4D471D9221A3545900E43468 /* Bundle.swift */,
 				4D452743219B60A2002637CF /* extra.json */,
 				4D22EB36219879EF00729769 /* Info.plist */,
-				4D5242CF21CD6F8100030720 /* ArrayTests.swift */,
+				CC4BF61323DB0BD100485D08 /* JSONCodableTests.swift */,
 				4D305DBC21A020F800CE9C84 /* JSONElementTests.swift */,
 				4D7E4D0621A6063800BFE359 /* JSONFileTestCase.swift */,
 				4D093AFE21B42A7B0097F14B /* JSONPatchGeneratorTests.swift */,
@@ -288,6 +291,7 @@
 				4D5242D021CD6F8100030720 /* ArrayTests.swift in Sources */,
 				4D0AF308219885A400E7F86B /* JSONPointerTests.swift in Sources */,
 				4D7E4D0921A60F2D00BFE359 /* TestFileTestCase.swift in Sources */,
+				CC4BF61423DB0BD100485D08 /* JSONCodableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/JSONPatch/JSONError.swift
+++ b/Sources/JSONPatch/JSONError.swift
@@ -29,3 +29,48 @@ public enum JSONError: Error {
     case missingRequiredPatchField(op: String, index: Int, field: String)
     case patchTestFailed(path: String, expected: Any, found: Any?)
 }
+
+extension JSONError: Equatable {
+    public static func ==(lhs: JSONError, rhs: JSONError) -> Bool {
+        switch lhs {
+        case .invalidObjectType:
+            if case .invalidObjectType = rhs {
+                return true
+            }
+            
+        case .invalidPointerSyntax:
+            if case .invalidPointerSyntax = rhs {
+                return true
+            }
+            
+        case .invalidPatchFormat:
+            if case .invalidPatchFormat = rhs {
+                return true
+            }
+            
+        case .referencesNonexistentValue:
+            if case .referencesNonexistentValue = rhs {
+                return true
+            }
+            
+        case .unknownPatchOperation:
+            if case .unknownPatchOperation = rhs {
+                return true
+            }
+            
+        case .missingRequiredPatchField(let op1, let index1, let field1):
+            if case .missingRequiredPatchField(let op2, let index2, let field2) = rhs,
+                op1 == op2 && index1 == index2 && field1 == field2 {
+                return true
+            }
+            
+        case .patchTestFailed(let path1, _, _):
+            if case .patchTestFailed(let path2, _, _) = rhs,
+                path1 == path2 {
+                return true
+            }
+        }
+        
+        return false
+    }
+}

--- a/Sources/JSONPatch/JSONPointer.swift
+++ b/Sources/JSONPatch/JSONPointer.swift
@@ -178,8 +178,8 @@ extension JSONPointer: Equatable {
 }
 
 extension JSONPointer: Hashable {
-    public var hashValue: Int {
-        return components.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(components)
     }
 }
 

--- a/Tests/JSONPatchTests/JSONCodableTests.swift
+++ b/Tests/JSONPatchTests/JSONCodableTests.swift
@@ -1,0 +1,59 @@
+//
+//  JSONPatchTests.swift
+//  JSONPatchTests
+//
+//  Created by Michiel Horvers on 01/24/2020.
+//  Copyright © 2020 Michiel Horvers.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import JSONPatch
+
+fileprivate struct Person: Codable {
+    var firstName: String
+    var lastName: String
+    var age: Int
+}
+
+class JSONCodableTests: XCTestCase {
+    
+    func testCreatePatch() throws {
+        let source = Person(firstName: "Michiel", lastName: "Horvers", age: 99)
+        let target = Person(firstName: "Michiel", lastName: "Horvers", age: 100)
+        
+        let patch = try JSONPatch.createPatch(from: source, to: target)
+        XCTAssert(patch.operations.count == 1, "Patch should have only 1 operation, but has \(patch.operations.count)")
+        
+        guard patch.operations.count == 1 else { return }
+        let dict = patch.operations[0].jsonObject
+        
+        XCTAssert((dict["op"] as? String) == "replace", "Operation should be 'replace', but is: \(String(describing: dict["op"]))")
+        XCTAssert((dict["path"] as? String) == "/age", "Path should be 'age', but is: \(String(describing: dict["path"]))")
+        XCTAssert((dict["value"] as? Int) == 100, "Value should be 100, but is: \(String(describing: dict["value"]))")
+    }
+    
+    func testApplyPatch() throws {
+        let person = Person(firstName: "Michiel", lastName: "Horvers", age: 99)
+        let patchData = Data("""
+        [
+            { "op": "replace", "path": "/age", "value": 100 }
+        ]
+        """.utf8)
+        let patch = try JSONDecoder().decode(JSONPatch.self, from: patchData)
+        
+        let patchedPerson = try patch.applied(to: person)
+        XCTAssert(patchedPerson.age == 100, "Age should be patchd to 100, but is: \(patchedPerson.age)")
+    }
+}


### PR DESCRIPTION
The way we are using objects, is that client side objects only have the properties they are interested in while remote side objects may contain lots of additional data we don't (need to) care about.

However, in case a JSON patch contains one of our valid properties and additionally one or more properties we don't know about, that patch will always fail and throw a `JSONError.referenceNonexistentValue` error.
This pull request adds the ability to ignore that specific error, and just continue applying all valid values.

Additionally, I've added some convenient functions for creating a patch from and applying one to a `Codable` object and fixed a deprecation warning of `Hashable`
