### PR TITLE
Copy operation of a numeric value would crash the app

### DIFF
--- a/Sources/JSONPatch/JSONPatch.swift
+++ b/Sources/JSONPatch/JSONPatch.swift
@@ -144,7 +144,7 @@ public class JSONPatch: Codable {
                       options: [ApplyOption] = []) throws -> Any {
         var jsonDocument = try JSONElement(any: jsonObject)
         if options.contains(.applyOnCopy) {
-            jsonDocument = jsonDocument.copy()
+            jsonDocument = try jsonDocument.copy()
         }
         try jsonDocument.apply(patch: self, options: options)
         return jsonDocument.rawValue

--- a/Tests/JSONPatchTests/JSONElementTests.swift
+++ b/Tests/JSONPatchTests/JSONElementTests.swift
@@ -59,4 +59,20 @@ class JSONElementTests: XCTestCase {
         XCTAssertEqual(jsonDecoded, jsonSerialization)
     }
 
+    func testCopy() throws {
+        do {
+            let int = try JSONElement(any: NSNumber(value: 0))
+            let string = try JSONElement(any: "Test")
+            let array = try JSONElement(any: [1, 2, 3])
+            let dict = try JSONElement(any: ["Test": 1])
+
+            let _ = try int.copy()
+            let _ = try string.copy()
+            let _ = try array.copy()
+            let _ = try dict.copy()
+        } catch {
+            XCTFail("Should not throw an exception, but caught: \(error)")
+        }
+    }
+
 }


### PR DESCRIPTION
Hey!
Found another issue:
When you've got a numeric value within a copy-operation, the app will crash.

Calling `mutableCopy` on an NSObject will, under the hood, automatically call `mutableCopyWithZone:`.
That one isn't implemented in NSNumber and will therefore crash at runtime due to an NSInvalidArgumentException.
