### PR TITLE
Linux Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ JSONPatch is a a swift module implements json-patch [RFC6902](https://tools.ietf
 The implementation uses the [JSON Patch Tests](https://github.com/json-patch/json-patch-tests) project for unit tests to validate its correctness.
 
 # Release
-1.0.5 - Updated minimum deployment targets in podspac for compatibility with Xcode 15.
+1.0.6 - Added support for Linux.
 
 # Installation
 

--- a/RMJSONPatch.podspec
+++ b/RMJSONPatch.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "RMJSONPatch"
-  s.version      = "1.0.5"
+  s.version      = "1.0.6"
   s.summary      = "JSONPatch is a swift library for applying and generating RFC-6902 compliant JSON patches."
   s.module_name  = "JSONPatch"
 

--- a/Sources/JSONPatch/JSONElement.swift
+++ b/Sources/JSONPatch/JSONElement.swift
@@ -158,7 +158,11 @@ extension JSONElement {
     private mutating func makeMutable() {
         switch self {
         case .object(let dictionary):
+            #if os(Linux)
+            let mutable = dictionary.mutableCopy() as! NSMutableDictionary
+            #else
             let mutable = NSMutableDictionary(dictionary: dictionary)
+            #endif
             self = .mutableObject(value: mutable)
         case .array(let array):
             let mutable = NSMutableArray(array: array)

--- a/Sources/JSONPatch/JSONEquality.swift
+++ b/Sources/JSONPatch/JSONEquality.swift
@@ -26,7 +26,11 @@ protocol JSONEquatable {
 
 extension NSNumber: JSONEquatable {
     var isBoolean: Bool {
+        #if os(Linux)
+        return objCType.pointee == 0x63 // character code for 'c'
+        #else
         return CFNumberGetType(self) == .charType
+        #endif
     }
 
     func isJSONEquals(to element: JSONElement) -> Bool {

--- a/Sources/JSONPatch/JSONEquality.swift
+++ b/Sources/JSONPatch/JSONEquality.swift
@@ -59,6 +59,12 @@ extension NSString: JSONEquatable {
     }
 }
 
+extension String: JSONEquatable {
+    func isJSONEquals(to element: JSONElement) -> Bool {
+        return (self as NSString).isJSONEquals(to: element)
+    }
+}
+
 extension NSNull: JSONEquatable {
     func isJSONEquals(to element: JSONElement) -> Bool {
         guard case .null = element else {
@@ -89,6 +95,12 @@ extension NSArray: JSONEquatable {
     }
 }
 
+extension Array: JSONEquatable {
+    func isJSONEquals(to element: JSONElement) -> Bool {
+        return (self as NSArray).isJSONEquals(to: element)
+    }
+}
+
 extension NSDictionary: JSONEquatable {
     func isJSONEquals(to element: JSONElement) -> Bool {
         switch element {
@@ -110,5 +122,11 @@ extension NSDictionary: JSONEquatable {
         default:
             return false
         }
+    }
+}
+
+extension Dictionary: JSONEquatable {
+    func isJSONEquals(to element: JSONElement) -> Bool {
+        return (self as NSDictionary).isJSONEquals(to: element)
     }
 }

--- a/Sources/JSONPatch/JSONPatchCodable.swift
+++ b/Sources/JSONPatch/JSONPatchCodable.swift
@@ -154,6 +154,18 @@ extension JSONPatch.Operation: Codable {
 extension SingleValueEncodingContainer {
 
     fileprivate mutating func encodeNSNumber(_ value: NSNumber) throws {
+        #if os(Linux)
+        switch value.objCType.pointee {
+        case 0x63:
+            try encode(value.boolValue)
+        case 0x64, 0x71, 0x51, 0x4C:
+            try encode(value.doubleValue)
+        case 0x66, 0x49:
+            try encode(value.floatValue)
+        default:
+            try encode(value.int64Value)
+        }
+        #else
         switch CFNumberGetType(value) {
         case .charType:
             try encode(value.boolValue)
@@ -164,6 +176,7 @@ extension SingleValueEncodingContainer {
         default:
             try encode(value.int64Value)
         }
+        #endif
     }
 }
 

--- a/Sources/JSONPatch/NSDictionary+DeepCopy.swift
+++ b/Sources/JSONPatch/NSDictionary+DeepCopy.swift
@@ -26,6 +26,20 @@ extension NSDictionary {
         let result = NSMutableDictionary()
 
         self.enumerateKeysAndObjects { (key, value, stop) in
+            #if os(Linux)
+            switch value {
+            case let array as NSArray:
+                result.setObject(array.deepMutableCopy(), forKey: key as! NSString)
+            case let dict as NSDictionary:
+                result.setObject(dict.deepMutableCopy(), forKey: key as! NSString)
+            case let str as NSMutableString:
+                result.setObject(str, forKey: key as! NSString)
+            case let obj as NSObject:
+                result.setObject(obj.copy(), forKey: key as! NSString)
+            default:
+                result.setObject(value, forKey: key as! NSString)
+            }
+            #else
             switch value {
             case let array as NSArray:
                 result[key] = array.deepMutableCopy()
@@ -38,6 +52,7 @@ extension NSDictionary {
             default:
                 result[key] = value
             }
+            #endif
         }
 
         return result


### PR DESCRIPTION
* Removed reliance on `CFNumberGetType` in favor of `objCType.pointee`
* Added direct support for native Swift types

Tested via deploying to a linux docker environment.